### PR TITLE
Fixed checkboxes and radios in FF on Android

### DIFF
--- a/css/sakura-dark-solarized.css
+++ b/css/sakura-dark-solarized.css
@@ -157,6 +157,9 @@ textarea, select, input[type] {
     border: 1px solid #2aa198;
     outline: 0; }
 
+input[type="checkbox"], input[type="radio"] {
+  padding: 0px; }
+
 input[type="checkbox"]:focus {
   outline: 1px dotted #2aa198; }
 

--- a/css/sakura-dark.css
+++ b/css/sakura-dark.css
@@ -157,6 +157,9 @@ textarea, select, input[type] {
     border: 1px solid #ffffff;
     outline: 0; }
 
+input[type="checkbox"], input[type="radio"] {
+  padding: 0px; }
+
 input[type="checkbox"]:focus {
   outline: 1px dotted #ffffff; }
 

--- a/css/sakura-earthly.css
+++ b/css/sakura-earthly.css
@@ -156,6 +156,9 @@ textarea, select, input[type] {
     border: 1px solid #338618;
     outline: 0; }
 
+input[type="checkbox"], input[type="radio"] {
+  padding: 0px; }
+
 input[type="checkbox"]:focus {
   outline: 1px dotted #338618; }
 

--- a/css/sakura-vader.css
+++ b/css/sakura-vader.css
@@ -157,6 +157,9 @@ textarea, select, input[type] {
     border: 1px solid #eb99a1;
     outline: 0; }
 
+input[type="checkbox"], input[type="radio"] {
+  padding: 0px; }
+
 input[type="checkbox"]:focus {
   outline: 1px dotted #eb99a1; }
 

--- a/css/sakura.css
+++ b/css/sakura.css
@@ -156,6 +156,9 @@ textarea, select, input[type] {
     border: 1px solid #2c8898;
     outline: 0; }
 
+input[type="checkbox"], input[type="radio"] {
+  padding: 0px; }
+
 input[type="checkbox"]:focus {
   outline: 1px dotted #2c8898; }
 

--- a/scss/_main.scss
+++ b/scss/_main.scss
@@ -189,6 +189,10 @@ textarea, select, input[type] {
     }
 }
 
+input[type="checkbox"], input[type="radio"] {
+    padding: 0px;
+}
+
 input[type="checkbox"]:focus {
     outline: 1px dotted $color-blossom;
 }


### PR DESCRIPTION
The tick in radio buttons and checkboxes were invisible in Firefox
on Android. From my testing, this change doesn't seem to affect anything else.

Here are two screenshots of a test page with Firefox on Android; one with the old version, one with this change. The same checkboxes and radio buttons are checked in both images.

![screenshot_2017-06-25-23-16-42](https://user-images.githubusercontent.com/3728194/27519868-8f93f5ba-59fd-11e7-9670-a8daa0ed04d2.png)
![screenshot_2017-06-25-23-16-15](https://user-images.githubusercontent.com/3728194/27519869-8f9570ac-59fd-11e7-9fff-64d69b7555ba.png)