### PR TITLE
Adds -webkit-appearance: none for input elements

### DIFF
--- a/scss/_main.scss
+++ b/scss/_main.scss
@@ -182,7 +182,8 @@ textarea, select, input[type] {
     border-radius: 4px;
     box-shadow: none;
     box-sizing: border-box;
-
+    -webkit-appearance: none;
+    
     &:focus {
         border: 1px solid $color-blossom;
         outline: 0;


### PR DESCRIPTION
This fixes input elements on iOS devices which otherwise would have a top inner shadow and the [type="search"] would look distinct.