### PR TITLE
CSS for a:visited

### DIFF
--- a/css/sakura-dark-solarized.css
+++ b/css/sakura-dark-solarized.css
@@ -71,6 +71,8 @@ a {
   a:hover {
     color: #657b83;
     border-bottom: 2px solid #839496; }
+  a:visited {
+    color: #1f7972; }
 
 ul {
   padding-left: 1.4em;
@@ -169,7 +171,8 @@ textarea, select, input {
   border: 1px solid #073642;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  -webkit-appearance: none; }
   textarea:focus, select:focus, input:focus {
     border: 1px solid #2aa198;
     outline: 0; }

--- a/css/sakura-dark.css
+++ b/css/sakura-dark.css
@@ -71,6 +71,8 @@ a {
   a:hover {
     color: #c9c9c9;
     border-bottom: 2px solid #c9c9c9; }
+  a:visited {
+    color: #e6e6e6; }
 
 ul {
   padding-left: 1.4em;
@@ -169,7 +171,8 @@ textarea, select, input {
   border: 1px solid #4a4a4a;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  -webkit-appearance: none; }
   textarea:focus, select:focus, input:focus {
     border: 1px solid #ffffff;
     outline: 0; }

--- a/css/sakura-earthly.css
+++ b/css/sakura-earthly.css
@@ -70,6 +70,8 @@ a {
   a:hover {
     color: #006994;
     border-bottom: 2px solid #222222; }
+  a:visited {
+    color: #004232; }
 
 ul {
   padding-left: 1.4em;
@@ -159,7 +161,6 @@ textarea {
     color: #ffffff;
     outline: 0; }
 
-
 textarea, select, input {
   color: #222222;
   padding: 6px 10px;
@@ -169,8 +170,9 @@ textarea, select, input {
   border: 1px solid #f7f7f7;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
-  textarea:focus, select:focus, input[type]:focus {
+  box-sizing: border-box;
+  -webkit-appearance: none; }
+  textarea:focus, select:focus, input:focus {
     border: 1px solid #007559;
     outline: 0; }
 

--- a/css/sakura-ink.css
+++ b/css/sakura-ink.css
@@ -70,6 +70,8 @@ a {
   a:hover {
     color: #DA4453;
     border-bottom: 2px solid rgba(0, 0, 0, 0.85); }
+  a:visited {
+    color: #2913c6; }
 
 ul {
   padding-left: 1.4em;
@@ -168,7 +170,8 @@ textarea, select, input {
   border: 1px solid #f7f7f7;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  -webkit-appearance: none; }
   textarea:focus, select:focus, input:focus {
     border: 1px solid #3b22ea;
     outline: 0; }

--- a/css/sakura-vader.css
+++ b/css/sakura-vader.css
@@ -71,6 +71,8 @@ a {
   a:hover {
     color: #DA4453;
     border-bottom: 2px solid #d9d8dc; }
+  a:visited {
+    color: #e26f7a; }
 
 ul {
   padding-left: 1.4em;
@@ -169,7 +171,8 @@ textarea, select, input {
   border: 1px solid #40363a;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  -webkit-appearance: none; }
   textarea:focus, select:focus, input:focus {
     border: 1px solid #eb99a1;
     outline: 0; }

--- a/css/sakura.css
+++ b/css/sakura.css
@@ -62,14 +62,16 @@ small, sub, sup {
   font-size: 75%; }
 
 hr {
-  border-color: #2c8898; }
+  border-color: #1d7484; }
 
 a {
   text-decoration: none;
-  color: #2c8898; }
+  color: #1d7484; }
   a:hover {
     color: #982c61;
     border-bottom: 2px solid #4a4a4a; }
+  a:visited {
+    color: #144f5a; }
 
 ul {
   padding-left: 1.4em;
@@ -86,7 +88,7 @@ blockquote {
   padding-top: 0.8em;
   padding-bottom: 0.8em;
   padding-right: 0.8em;
-  border-left: 5px solid #2c8898;
+  border-left: 5px solid #1d7484;
   margin-bottom: 2.5rem;
   background-color: #f1f1f1; }
 
@@ -133,7 +135,7 @@ td, th {
 input, textarea {
   border: 1px solid #4a4a4a; }
   input:focus, textarea:focus {
-    border: 1px solid #2c8898; }
+    border: 1px solid #1d7484; }
 
 textarea {
   width: 100%; }
@@ -144,10 +146,10 @@ textarea {
   text-align: center;
   text-decoration: none;
   white-space: nowrap;
-  background-color: #2c8898;
+  background-color: #1d7484;
   color: #f9f9f9;
   border-radius: 1px;
-  border: 1px solid #2c8898;
+  border: 1px solid #1d7484;
   cursor: pointer;
   box-sizing: border-box; }
   .button[disabled], button[disabled], input[type="submit"][disabled], input[type="reset"][disabled], input[type="button"][disabled] {
@@ -168,13 +170,14 @@ textarea, select, input {
   border: 1px solid #f1f1f1;
   border-radius: 4px;
   box-shadow: none;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+  -webkit-appearance: none; }
   textarea:focus, select:focus, input:focus {
-    border: 1px solid #2c8898;
+    border: 1px solid #1d7484;
     outline: 0; }
 
 input[type="checkbox"]:focus {
-  outline: 1px dotted #2c8898; }
+  outline: 1px dotted #1d7484; }
 
 label, legend, fieldset {
   display: block;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sakura.css",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scss/_main.scss
+++ b/scss/_main.scss
@@ -79,6 +79,10 @@ a {
         border-bottom: 2px solid $color-text;
     }
 
+    &:visited {
+        color: darken($color-blossom, 10%);
+    }
+
 }
 
 ul {


### PR DESCRIPTION
This fixes #40. I first tried with `darken($color-fade, 20%)` but found that it was too dark. After a bit of testing, I've settled for `darken($color-blossom, 10%)`.

All new colors meet the WCAG 2.0 AA standards.

There's also changes to the sakura.css files not related to my changes, I think it's due to the last pull request not pushing the changes to the css files.

On sakura:
![sakura](https://user-images.githubusercontent.com/55180995/94339786-c890dd80-fffc-11ea-8044-461bf51c91bc.png)

On sakura-dark:
![sakura-dark](https://user-images.githubusercontent.com/55180995/94339744-8b2c5000-fffc-11ea-8b99-b071c4dad91a.png)

On sakura-vader:
![sakura-vader](https://user-images.githubusercontent.com/55180995/94339745-8bc4e680-fffc-11ea-926f-45c9948df572.png)

On sakura-earthly:
![sakura-earthly](https://user-images.githubusercontent.com/55180995/94339747-8bc4e680-fffc-11ea-8570-e76db229da63.png)




