### PR TITLE
Make code, kbd, and samp all style the same way

### DIFF
--- a/css/sakura-dark-solarized.css
+++ b/css/sakura-dark-solarized.css
@@ -112,7 +112,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #073642;

--- a/css/sakura-dark.css
+++ b/css/sakura-dark.css
@@ -112,7 +112,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #4a4a4a;

--- a/css/sakura-earthly.css
+++ b/css/sakura-earthly.css
@@ -111,7 +111,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #f7f7f7;

--- a/css/sakura-ink.css
+++ b/css/sakura-ink.css
@@ -111,7 +111,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #f7f7f7;

--- a/css/sakura-pink.css
+++ b/css/sakura-pink.css
@@ -108,9 +108,10 @@ pre {
   padding: 1em;
   overflow-x: auto;
   margin-top: 0px;
-  margin-bottom: 2.5rem; }
+  margin-bottom: 2.5rem;
+  font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #f8d2e9;
@@ -119,7 +120,8 @@ code {
 pre > code {
   padding: 0;
   background-color: transparent;
-  white-space: pre; }
+  white-space: pre;
+  font-size: 1em; }
 
 /* Tables */
 table {

--- a/css/sakura-vader.css
+++ b/css/sakura-vader.css
@@ -112,7 +112,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #40363a;

--- a/css/sakura.css
+++ b/css/sakura.css
@@ -111,7 +111,7 @@ pre {
   margin-bottom: 2.5rem;
   font-size: 0.9em; }
 
-code {
+code, kbd, samp {
   font-size: 0.9em;
   padding: 0 0.5em;
   background-color: #f1f1f1;

--- a/scss/_main.scss
+++ b/scss/_main.scss
@@ -130,7 +130,7 @@ pre {
     font-size: 0.9em;
 }
 
-code {
+code, kbd, samp {
     font-size: 0.9em;
     padding: 0 0.5em;
     background-color: $color-bg-alt;


### PR DESCRIPTION
In default HTML styles, `<code>`, `<kbd>` (keyboard button), and `<samp>` (output sample) all style the same way. (These are all showcased next to each other in the "Code" section of [test.html](https://github.com/oxalorg/sakura/blob/6b81c1158f280a333407ea83babb3fd9e920123e/test.html).) Currently, only `<code>` is styled with some with some padding and a gray background color. This PR extends that style to apply to keyboard buttons and output samples as well. I think this is especially useful for `<kbd>`, since a common styling for this element is to make it look like a physical keyboard key, and the gray background and padding help to give this effect.

Also, thank you for creating Sakura! It's really wonderful.