### PR TITLE
Allow hover styles to work on visited links

### DIFF
--- a/css/sakura-dark-solarized.css
+++ b/css/sakura-dark-solarized.css
@@ -68,11 +68,11 @@ hr {
 a {
   text-decoration: none;
   color: #2aa198; }
+  a:visited {
+    color: #1f7972; }
   a:hover {
     color: #657b83;
     border-bottom: 2px solid #839496; }
-  a:visited {
-    color: #1f7972; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura-dark.css
+++ b/css/sakura-dark.css
@@ -68,11 +68,11 @@ hr {
 a {
   text-decoration: none;
   color: #ffffff; }
+  a:visited {
+    color: #e6e6e6; }
   a:hover {
     color: #c9c9c9;
     border-bottom: 2px solid #c9c9c9; }
-  a:visited {
-    color: #e6e6e6; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura-earthly.css
+++ b/css/sakura-earthly.css
@@ -67,11 +67,11 @@ hr {
 a {
   text-decoration: none;
   color: #007559; }
+  a:visited {
+    color: #004232; }
   a:hover {
     color: #006994;
     border-bottom: 2px solid #222222; }
-  a:visited {
-    color: #004232; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura-ink.css
+++ b/css/sakura-ink.css
@@ -67,11 +67,11 @@ hr {
 a {
   text-decoration: none;
   color: #3b22ea; }
+  a:visited {
+    color: #2913c6; }
   a:hover {
     color: #DA4453;
     border-bottom: 2px solid rgba(0, 0, 0, 0.85); }
-  a:visited {
-    color: #2913c6; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura-pink.css
+++ b/css/sakura-pink.css
@@ -67,11 +67,11 @@ hr {
 a {
   text-decoration: none;
   color: #980255; }
+  a:visited {
+    color: #660139; }
   a:hover {
     color: #753851;
     border-bottom: 2px solid #49002d; }
-  a:visited {
-    color: #660139; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura-vader.css
+++ b/css/sakura-vader.css
@@ -68,11 +68,11 @@ hr {
 a {
   text-decoration: none;
   color: #eb99a1; }
+  a:visited {
+    color: #e26f7a; }
   a:hover {
     color: #DA4453;
     border-bottom: 2px solid #d9d8dc; }
-  a:visited {
-    color: #e26f7a; }
 
 ul {
   padding-left: 1.4em;

--- a/css/sakura.css
+++ b/css/sakura.css
@@ -67,11 +67,11 @@ hr {
 a {
   text-decoration: none;
   color: #1d7484; }
+  a:visited {
+    color: #144f5a; }
   a:hover {
     color: #982c61;
     border-bottom: 2px solid #4a4a4a; }
-  a:visited {
-    color: #144f5a; }
 
 ul {
   padding-left: 1.4em;

--- a/scss/_main.scss
+++ b/scss/_main.scss
@@ -74,13 +74,13 @@ a {
     text-decoration: none;
     color: $color-blossom;
 
+    &:visited {
+        color: darken($color-blossom, 10%);
+    }
+
     &:hover {
         color: $color-fade;
         border-bottom: 2px solid $color-text;
-    }
-
-    &:visited {
-        color: darken($color-blossom, 10%);
     }
 
 }


### PR DESCRIPTION
CSS overrides any `:visited` styles if they're defined after `:hover` styles.

Hover styles can be made to work properly on visited links by moving the `:hover` to after `:visited`.

Before:

https://user-images.githubusercontent.com/20013884/177930326-8a8f462c-4a74-4541-a84b-b396eb367042.mp4

After:

https://user-images.githubusercontent.com/20013884/177930359-bdeea0bb-5dd7-4d16-acf4-90de34413680.mp4
