### PR TITLE
Fix scrolling div background

### DIFF
--- a/css/sakura-dark.css
+++ b/css/sakura-dark.css
@@ -221,3 +221,7 @@ label, legend, fieldset {
   margin-bottom: 0.5rem;
   font-weight: 600;
 }
+
+div {
+   background-color: #4a4a4a
+}


### PR DESCRIPTION
When a div overflows and you scroll to the right, the background color gets cut off. The background color was set to the item inside the div, not the div itself. This fixes it