### PR TITLE
Add new theme "radical"

### DIFF
--- a/css/sakura-radical.css
+++ b/css/sakura-radical.css
@@ -1,0 +1,222 @@
+/* Sakura.css v1.4.1
+ * ================
+ * Minimal css theme.
+ * Project: https://github.com/oxalorg/sakura/
+ */
+/* Body */
+html {
+  font-size: 62.5%;
+  font-family: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+}
+
+body {
+  font-size: 1.8rem;
+  line-height: 1.618;
+  max-width: 38em;
+  margin: auto;
+  color: #32cd32;
+  background-color: #000000;
+  padding: 13px;
+}
+
+@media (max-width: 684px) {
+  body {
+    font-size: 1.53rem;
+  }
+}
+@media (max-width: 382px) {
+  body {
+    font-size: 1.35rem;
+  }
+}
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.1;
+  font-family: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+  font-weight: 700;
+  margin-top: 3rem;
+  margin-bottom: 1.5rem;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+  word-break: break-word;
+}
+
+h1 {
+  font-size: 2.35em;
+}
+
+h2 {
+  font-size: 2em;
+}
+
+h3 {
+  font-size: 1.75em;
+}
+
+h4 {
+  font-size: 1.5em;
+}
+
+h5 {
+  font-size: 1.25em;
+}
+
+h6 {
+  font-size: 1em;
+}
+
+p {
+  margin-top: 0px;
+  margin-bottom: 2.5rem;
+}
+
+small, sub, sup {
+  font-size: 75%;
+}
+
+hr {
+  border-color: #D415D4;
+}
+
+a {
+  text-decoration: none;
+  color: #D415D4;
+}
+a:visited {
+  color: #a610a6;
+}
+a:hover {
+  color: #00ffff;
+  border-bottom: 2px solid #32cd32;
+}
+
+ul {
+  padding-left: 1.4em;
+  margin-top: 0px;
+  margin-bottom: 2.5rem;
+}
+
+li {
+  margin-bottom: 0.4em;
+}
+
+blockquote {
+  margin-left: 0px;
+  margin-right: 0px;
+  padding-left: 1em;
+  padding-top: 0.8em;
+  padding-bottom: 0.8em;
+  padding-right: 0.8em;
+  border-left: 5px solid #D415D4;
+  margin-bottom: 2.5rem;
+  background-color: #1b1e24;
+}
+
+blockquote p {
+  margin-bottom: 0;
+}
+
+img, video {
+  height: auto;
+  max-width: 100%;
+  margin-top: 0px;
+  margin-bottom: 2.5rem;
+}
+
+/* Pre and Code */
+pre {
+  background-color: #1b1e24;
+  display: block;
+  padding: 1em;
+  overflow-x: auto;
+  margin-top: 0px;
+  margin-bottom: 2.5rem;
+  font-size: 0.9em;
+}
+
+code, kbd, samp {
+  font-size: 0.9em;
+  padding: 0 0.5em;
+  background-color: #1b1e24;
+  white-space: pre-wrap;
+}
+
+pre > code {
+  padding: 0;
+  background-color: transparent;
+  white-space: pre;
+  font-size: 1em;
+}
+
+/* Tables */
+table {
+  text-align: justify;
+  width: 100%;
+  border-collapse: collapse;
+}
+
+td, th {
+  padding: 0.5em;
+  border-bottom: 1px solid #1b1e24;
+}
+
+/* Buttons, forms and input */
+input, textarea {
+  border: 1px solid #32cd32;
+}
+input:focus, textarea:focus {
+  border: 1px solid #D415D4;
+}
+
+textarea {
+  width: 100%;
+}
+
+.button, button, input[type=submit], input[type=reset], input[type=button] {
+  display: inline-block;
+  padding: 5px 10px;
+  text-align: center;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: #D415D4;
+  color: #000000;
+  border-radius: 1px;
+  border: 1px solid #D415D4;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.button[disabled], button[disabled], input[type=submit][disabled], input[type=reset][disabled], input[type=button][disabled] {
+  cursor: default;
+  opacity: 0.5;
+}
+.button:focus:enabled, .button:hover:enabled, button:focus:enabled, button:hover:enabled, input[type=submit]:focus:enabled, input[type=submit]:hover:enabled, input[type=reset]:focus:enabled, input[type=reset]:hover:enabled, input[type=button]:focus:enabled, input[type=button]:hover:enabled {
+  background-color: #00ffff;
+  border-color: #00ffff;
+  color: #000000;
+  outline: 0;
+}
+
+textarea, select, input {
+  color: #32cd32;
+  padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
+  margin-bottom: 10px;
+  background-color: #1b1e24;
+  border: 1px solid #1b1e24;
+  border-radius: 4px;
+  box-shadow: none;
+  box-sizing: border-box;
+}
+textarea:focus, select:focus, input:focus {
+  border: 1px solid #D415D4;
+  outline: 0;
+}
+
+input[type=checkbox]:focus {
+  outline: 1px dotted #D415D4;
+}
+
+label, legend, fieldset {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}

--- a/css/sakura-radical.css
+++ b/css/sakura-radical.css
@@ -6,7 +6,7 @@
 /* Body */
 html {
   font-size: 62.5%;
-  font-family: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+  font-family: "SF Mono", "Menlo", "Consolas", "Noto Mono", "Courier New", Courier, monospace;
 }
 
 body {
@@ -31,7 +31,7 @@ body {
 }
 h1, h2, h3, h4, h5, h6 {
   line-height: 1.1;
-  font-family: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+  font-family: "SF Mono", "Menlo", "Consolas", "Noto Mono", "Courier New", Courier, monospace;
   font-weight: 700;
   margin-top: 3rem;
   margin-bottom: 1.5rem;

--- a/scss/sakura-radical.scss
+++ b/scss/sakura-radical.scss
@@ -1,0 +1,15 @@
+
+$color-blossom: #D415D4;
+$color-fade: #00ffff;
+
+$color-bg: #000000;
+$color-bg-alt: #1b1e24;
+
+$color-text: #32cd32;
+$font-size-base: 1.8rem;
+
+$font-family-base: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+$font-family-heading: $font-family-base;
+
+
+@import "main";

--- a/scss/sakura-radical.scss
+++ b/scss/sakura-radical.scss
@@ -8,7 +8,7 @@ $color-bg-alt: #1b1e24;
 $color-text: #32cd32;
 $font-size-base: 1.8rem;
 
-$font-family-base: "SF Mono", "Consolas", "Courier New", Courier, monospace;
+$font-family-base: "SF Mono", "Menlo", "Consolas", "Noto Mono", "Courier New", Courier, monospace;
 $font-family-heading: $font-family-base;
 
 


### PR DESCRIPTION
Add a new monospaced theme called "radical" inspired by terminal interfaces.

Font choice: 
"SF Mono", "Menlo" for Mac 
"Consolas" for Windows 
"Noto Mono" because other Sakura themes use "Noto sans"
"Courier New", Courier, monospace as fallback [according to w3schools](https://www.w3schools.com/css//css_font_fallbacks.asp).

Tested on FF and Chrome. Also checked on Windows and Mac and Android with AMOLED (reason for full black background).
Also checked against FF colorblindness simulations.

The theme is named after hacker prodigy Radical Ed from Cowboy Bebop and also because it feels radically different from other Sakura themes 😄 

Example:
![radical_screenshot](https://user-images.githubusercontent.com/35447833/204663377-c3fd6fe8-9f04-4354-a974-4a53c8317cdd.png)
