### PR TITLE
Moves [disabled] selector in front of ::file-selector-button

### DIFF
--- a/css/sakura.css
+++ b/css/sakura.css
@@ -186,7 +186,7 @@ textarea {
   cursor: pointer;
   box-sizing: border-box;
 }
-.button[disabled], button[disabled], input[type=submit][disabled], input[type=reset][disabled], input[type=button][disabled], input[type=file]::file-selector-button[disabled] {
+.button[disabled], button[disabled], input[type=submit][disabled], input[type=reset][disabled], input[type=button][disabled], input[type=file][disabled]::file-selector-button {
   cursor: default;
   opacity: 0.5;
 }


### PR DESCRIPTION
When I tried using using sakura.css with [Parcel](https://parceljs.org/), I received the following confusing error:

> @parcel/transformer-css: Invalid state

It turned out that this `[disabled]` selector is to blame, since per [Selectors Level 4 spec](https://drafts.csswg.org/selectors/#pseudo-element-syntax):

> [Pseudo-elements](https://drafts.csswg.org/selectors/#pseudo-element) are [featureless](https://drafts.csswg.org/selectors/#featureless), and so can’t be matched by any other selector.